### PR TITLE
docs: fix variable name in example, that caused mapkit namespace to b…

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # Leaflet.MapkitMutant
 
 A [LeafletJS](http://leafletjs.com/) plugin to
-use [Apple's mapkitJS](https://developer.apple.com/documentation/mapkitjs) maps as a base layer.
+use [Apple's MapKit JS](https://developer.apple.com/documentation/mapkitjs) maps as a base layer.
 
-The name comes from [GoogleMutant](https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant). It's catchy, even if
-MapkitMutant doesn't use DOM mutation observers.
 This plugin is a fork of the original [Leaflet.MapkitMutant](https://gitlab.com/IvanSanchez/Leaflet.MapkitMutant) by
 [Ivan Sanchez Ortega](https://gitlab.com/IvanSanchez).
+The name comes from [GoogleMutant](https://gitlab.com/IvanSanchez/Leaflet.GridLayer.GoogleMutant). It's catchy, even if
+MapkitMutant doesn't use DOM mutation observers.
 
 ![Leaflet showing the three different mapkitjs map types](docs/demo.gif)
 
@@ -106,6 +106,7 @@ var mapkit = L.mapkitMutant({
 
 The full list of options can be found in
 the [Apple documentation](https://developer.apple.com/documentation/mapkitjs/mapconstructoroptions#3001292).
+_Be aware that some of the options might not work as expected, as the plugin is still in development._
 
 ## Known issues
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ and then the plugin itself. Replace `Your authorization token goes here` with yo
 <div id="map"></div>
 <script>
   var map = L.map("map").setView([48.20849, 16.37208], 16);
-  var mapkit = L.mapkitMutant({
+  var mapkitLayer = L.mapkitMutant({
     authorizationCallback: (done) => {
       done("Your authorization token goes here");
     },

--- a/src/Leaflet.MapkitMutant.ts
+++ b/src/Leaflet.MapkitMutant.ts
@@ -225,7 +225,7 @@ var _mapRect: mapkit.MapRect | null = null;
 	// This depends on the current map center, as to shift the bounds on
 	// multiples of 360 in order to prevent artifacts when crossing the
 	// antimeridian.
-	_mapkitRectToLeafletBounds: function (rect) {
+	_mapkitRectToLeafletBounds: function (rect: mapkit.MapRect) {
 		// Ask MapkitJS to provide the lat-lng coords of the rect's corners
 		var nw = new mapkit.MapPoint(rect.minX(), rect.maxY()).toCoordinate();
 		var se = new mapkit.MapPoint(rect.maxX(), rect.minY()).toCoordinate();


### PR DESCRIPTION
…e shadowed